### PR TITLE
Hooks: allow closure usage

### DIFF
--- a/third_party/DevelBar/hooks/Develbar.php
+++ b/third_party/DevelBar/hooks/Develbar.php
@@ -414,17 +414,19 @@ class Develbar
         $hooks = array();
 
         foreach ($this->CI->hooks->hooks as $hook_point => $_hooks) {
-            if (!isset($_hooks[0])) {
-                $_hooks = array($_hooks);
-            }
-            foreach ($_hooks as $hook) {
-                if (!array_key_exists('class', $hook)) {
-                    $hooks[$hook_point][] = $hook;
-                    $total_hooks++;
+            if (is_array($_hooks)) {
+                if (!isset($_hooks[0])) {
+                    $_hooks = array($_hooks);
                 }
-                elseif (class_exists($hook['class']) && get_class($this) != $hook['class']) {
-                    $hooks[$hook_point][] = $hook;
-                    $total_hooks++;
+                foreach ($_hooks as $hook) {
+                    if (!array_key_exists('class', $hook)) {
+                        $hooks[$hook_point][] = $hook;
+                        $total_hooks++;
+                    }
+                    elseif (class_exists($hook['class']) && get_class($this) != $hook['class']) {
+                        $hooks[$hook_point][] = $hook;
+                        $total_hooks++;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Hi, noticed that Develbar don't allow use to use closure hook like this : 

$hook['post_controller'] = function()
{
        /* do something here */
};
(https://www.codeigniter.com/user_guide/general/hooks.html)
I propose yopu a quick fix to avoid a crash.

It's not optimal because it don't fit closure hook in Develbar, but with
this fix, develbar doesn't crash when closure hook is used.

Thank you for Develbar, it's usefull !